### PR TITLE
Add encoder module and CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
 # Gpt
+
+## Encoder CLI
+
+This repository provides an example encoder/decoder that chains random reversible
+transformations. The CLI is located at `scripts/run_encode.py`.
+
+```
+./scripts/run_encode.py encode "Hello" --meta meta.json
+./scripts/run_encode.py decode <encoded> meta.json
+```
+
+### Available Transformations
+
+* **Caesar shift** – shifts alphabetical characters by a random amount.
+* **XOR** – applies a byte-wise XOR with a random integer key.
+* **Substitution** – substitutes printable ASCII characters using a random mapping.
+* **Base64** – encodes or decodes using Base64.
+
+### Extending
+
+Add a new transformation by updating `src/encoder.py`:
+
+1. Implement a pair of functions for encode/decode.
+2. Register them in `TRANSFORMATIONS` with a unique name.
+3. Include any random parameters in the metadata so `decode` can reverse them.
+

--- a/scripts/run_encode.py
+++ b/scripts/run_encode.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import sys
+from pathlib import Path
+import os
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+
+from src.encoder import encode, decode, Metadata, StepMeta
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Encode or decode messages")
+    subparsers = parser.add_subparsers(dest="command")
+
+    enc_parser = subparsers.add_parser("encode", help="Encode a message")
+    enc_parser.add_argument("message", help="Message to encode")
+    enc_parser.add_argument("--meta", help="Path to write metadata", default=None)
+
+    dec_parser = subparsers.add_parser("decode", help="Decode a message")
+    dec_parser.add_argument("encoded", help="Encoded message")
+    dec_parser.add_argument("metadata", help="Path to metadata JSON file")
+
+    args = parser.parse_args()
+
+    if args.command == "encode":
+        encoded, meta = encode(args.message)
+        print(encoded)
+        if args.meta:
+            Path(args.meta).write_text(json.dumps(meta, default=lambda o: o.__dict__, indent=2))
+    elif args.command == "decode":
+        data = json.loads(Path(args.metadata).read_text())
+        steps = [StepMeta(name=s['name'], params=s['params']) for s in data['steps']]
+        meta = Metadata(steps=steps)
+        print(decode(args.encoded, meta))
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/encoder.py
+++ b/src/encoder.py
@@ -1,0 +1,117 @@
+import base64
+import random
+from dataclasses import dataclass
+from typing import Any, Dict, List, Tuple
+
+# Define available transformations
+
+def _caesar_shift(text: str, shift: int) -> str:
+    result = []
+    for ch in text:
+        if 'a' <= ch <= 'z':
+            base = ord('a')
+            result.append(chr((ord(ch) - base + shift) % 26 + base))
+        elif 'A' <= ch <= 'Z':
+            base = ord('A')
+            result.append(chr((ord(ch) - base + shift) % 26 + base))
+        else:
+            result.append(ch)
+    return ''.join(result)
+
+def _caesar_unshift(text: str, shift: int) -> str:
+    return _caesar_shift(text, -shift)
+
+
+def _xor(text: str, key: int) -> str:
+    return ''.join(chr(ord(ch) ^ key) for ch in text)
+
+
+def _substitute(text: str, mapping: Dict[str, str]) -> str:
+    return ''.join(mapping.get(ch, ch) for ch in text)
+
+def _reverse_substitute(text: str, mapping: Dict[str, str]) -> str:
+    rev = {v: k for k, v in mapping.items()}
+    return ''.join(rev.get(ch, ch) for ch in text)
+
+
+def _base64_encode(text: str) -> str:
+    return base64.b64encode(text.encode()).decode()
+
+
+def _base64_decode(text: str) -> str:
+    return base64.b64decode(text.encode()).decode()
+
+
+TRANSFORMATIONS = {
+    'caesar': (_caesar_shift, _caesar_unshift),
+    'xor': (_xor, _xor),  # XOR is symmetric
+    'substitution': (_substitute, _reverse_substitute),
+    'base64': (_base64_encode, _base64_decode),
+}
+
+@dataclass
+class StepMeta:
+    name: str
+    params: Dict[str, Any]
+
+
+@dataclass
+class Metadata:
+    steps: List[StepMeta]
+
+
+def encode(message: str) -> Tuple[str, Metadata]:
+    """Apply random transformations to the message.
+
+    Returns the encoded message and metadata needed to reverse it.
+    """
+    available = list(TRANSFORMATIONS.keys())
+    num_steps = random.randint(1, len(available))
+    steps = random.sample(available, num_steps)
+
+    meta_steps = []
+    encoded = message
+    for step in steps:
+        if step == 'caesar':
+            shift = random.randint(1, 25)
+            encoded = TRANSFORMATIONS[step][0](encoded, shift)
+            meta_steps.append(StepMeta(name=step, params={'shift': shift}))
+        elif step == 'xor':
+            key = random.randint(1, 255)
+            encoded = TRANSFORMATIONS[step][0](encoded, key)
+            meta_steps.append(StepMeta(name=step, params={'key': key}))
+        elif step == 'substitution':
+            letters = [chr(i) for i in range(32, 127)]
+            shuffled = letters[:]
+            random.shuffle(shuffled)
+            mapping = dict(zip(letters, shuffled))
+            encoded = TRANSFORMATIONS[step][0](encoded, mapping)
+            meta_steps.append(StepMeta(name=step, params={'mapping': mapping}))
+        elif step == 'base64':
+            encoded = TRANSFORMATIONS[step][0](encoded)
+            meta_steps.append(StepMeta(name=step, params={}))
+        else:
+            raise ValueError(f'Unknown step {step}')
+    metadata = Metadata(steps=meta_steps)
+    return encoded, metadata
+
+
+def decode(encoded_text: str, metadata: Metadata) -> str:
+    """Reverse the encoding using metadata."""
+    decoded = encoded_text
+    for step in reversed(metadata.steps):
+        name = step.name
+        params = step.params
+        transform = TRANSFORMATIONS[name][1]
+        if name == 'caesar':
+            decoded = transform(decoded, params['shift'])
+        elif name == 'xor':
+            decoded = transform(decoded, params['key'])
+        elif name == 'substitution':
+            decoded = transform(decoded, params['mapping'])
+        elif name == 'base64':
+            decoded = transform(decoded)
+        else:
+            raise ValueError(f'Unknown step {name}')
+    return decoded
+


### PR DESCRIPTION
## Summary
- add encoder module with random reversible transformations
- create command line interface for encoding & decoding messages
- document available transformations and extension instructions

## Testing
- `python3 -m py_compile src/encoder.py scripts/run_encode.py`
- `python3 scripts/run_encode.py encode "Hello" --meta meta.json`
- `python3 scripts/run_encode.py decode "5x~.fxw|" meta.json`

------
https://chatgpt.com/codex/tasks/task_e_6852d7d33c88832389964efda1fadf86